### PR TITLE
Local run fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ v1/utilities/scripts/credentials.py
 venv
 
 !v2/credentials.ts
-!credentials.ts
+credentials.ts
 !v1/credentials.ts
 v2/utilities/scripts/credentials.py
 

--- a/v2/credentials.ts
+++ b/v2/credentials.ts
@@ -1,9 +1,5 @@
 exports.pg = {
-  host: process.env.host,
-  port: process.env.port,
-  user: process.env.user,
-  password: process.env.password,
-  database: process.env.database
+  connectionString: process.env.MACROSTRAT_DATABASE,
 };
 
 exports.postgresDatabases = {
@@ -18,4 +14,5 @@ exports.redis = {
 };
 
 // Generate a hash by running: node -e "console.log(require('uuid/v4')())"
+// NOTE: this is outdated and may not be used
 exports.cacheRefreshKey = "put-hash-here";

--- a/v2/units.ts
+++ b/v2/units.ts
@@ -568,9 +568,6 @@ module.exports = function (req, res, next, cb) {
         LEFT JOIN macrostrat_temp.unit_notes ON unit_notes.unit_id=units.id
         WHERE
           ${where}
-        GROUP BY units.id, units_sections.section_id, lookup_units.t_age, units_sections.col_id,
-         cols.project_id, cols.col_area, unit_strat_names.strat_name_id, mbr_name, fm_name, gp_name, sgp_name,
-         lookup_units.b_age,lookup_units.pbdb_collections, lookup_units.pbdb_occurrences
       ORDER BY ${orderby.length > 0 ? orderby.join(", ") + "," : ""} lookup_units.t_age ASC
       ${limit}
       `;


### PR DESCRIPTION
Fixes for running locally and initial app startup:

- Fix `/units?response=long` by reworking control flow and eliminating top-level `group by` statement
- Make credential files use the `MACROSTRAT_DATABASE` connection URL environment variable rather than a set of variables for each component