### PR TITLE
fixed units bug and added logging for pool connections

### DIFF
--- a/api-tests/v2Tests/units.ts
+++ b/api-tests/v2Tests/units.ts
@@ -247,6 +247,76 @@ it("should accept a project_id", function (done) {
     });
 });
 
+it("should return units for a col_id even when the column is outside core projects", function (done) {
+  this.timeout(10000);
+  request(settings.host)
+    .get("/units?col_id=4320&response=long")
+    .expect(validators.aSuccessfulRequest)
+    .expect(validators.json)
+    .expect(validators.atLeastOneResult)
+    .expect(function (res: { body: { success: { data: any[] } } }) {
+      res.body.success.data.forEach(function (d) {
+        if (d.col_id !== 4320) {
+          throw new Error("Wrong col_id returned when filtering by col_id");
+        }
+        if (d.project_id !== 3) {
+          throw new Error("Wrong project_id returned for col_id=4320");
+        }
+      });
+    })
+    .end(function (error: any, res: any) {
+      if (error) return done(error);
+      done();
+    });
+});
+
+it("should return units when col_id and the correct project_id are both provided", function (done) {
+  this.timeout(10000);
+  request(settings.host)
+    .get("/units?col_id=4320&project_id=3&response=long")
+    .expect(validators.aSuccessfulRequest)
+    .expect(validators.json)
+    .expect(validators.atLeastOneResult)
+    .expect(function (res: { body: { success: { data: any[] } } }) {
+      res.body.success.data.forEach(function (d) {
+        if (d.col_id !== 4320 || d.project_id !== 3) {
+          throw new Error("Wrong units returned when filtering by col_id and project_id");
+        }
+      });
+    })
+    .end(function (error: any, res: any) {
+      if (error) return done(error);
+      done();
+    });
+});
+
+it("should return an empty response when col_id and project_id do not match", async function () {
+  const uri = "/units?col_id=4320&project_id=4&response=long";
+  await request(settings.host)
+    .get(uri)
+    .expect(validators.returnsNoItems);
+});
+
+it("should limit units to the specified project_id when project_id is provided without col_id", function (done) {
+  this.timeout(15000);
+  request(settings.host)
+    .get("/units?project_id=3&response=long")
+    .expect(validators.aSuccessfulRequest)
+    .expect(validators.json)
+    .expect(validators.atLeastOneResult)
+    .expect(function (res: { body: { success: { data: any[] } } }) {
+      res.body.success.data.forEach(function (d) {
+        if (d.project_id !== 3) {
+          throw new Error("Units route did not limit results to project_id=3");
+        }
+      });
+    })
+    .end(function (error: any, res: any) {
+      if (error) return done(error);
+      done();
+    });
+});
+
 //fixed api this test works now
 it("should accept a strat_name parameter", function (done) {
   request(settings.host)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/api-v2",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "An API for stratigraphic and geological information (Version 2).",
   "main": "server.ts",
   "repository": {

--- a/v2/larkin.ts
+++ b/v2/larkin.ts
@@ -94,8 +94,15 @@ enum APICapability {
       }
     }
 
+
+
+    //logs any pool connection problems so pod network issues can be identified
     if (!connectionPoolStore[dbName]) {
-      connectionPoolStore[dbName] = new Pool(connectionDetails);
+      const pool = new Pool({ ...connectionDetails, connectionTimeoutMillis: 10000 });
+      pool.on("error", (err) => {
+        larkin.log("error", `Unexpected error on idle pool client: ${err.message}`);
+      });
+      connectionPoolStore[dbName] = pool;
     }
 
     const pool = connectionPoolStore[dbName];
@@ -133,11 +140,7 @@ enum APICapability {
             done();
             if (err) {
               larkin.log("error", err);
-              if (err.message.includes(errorMessage)) {
-                callback(null, { rows: [] });
-              } else {
                 callback(err);
-              }
             } else {
               callback(null, result);
             }
@@ -201,13 +204,19 @@ enum APICapability {
         .send(JSON.stringify(outgoing.data, null, 0));
     }
 
+    //added error handling if refs query returns an error
     if (options.refs) {
-      larkin.getRefs(options.refs, outgoing.data, function (refs) {
+      larkin.getRefs(options.refs, outgoing.data, function (error, refs) {
+        if (error) {
+          larkin.log("error", error);
+          return larkin.error(req, res, next, error.message, 500);
+        }
+
         outgoing.refs = refs;
-        larkin.finishSend(req, res, next, options, outgoing);
+        return larkin.finishSend(req, res, next, options, outgoing);
       });
     } else {
-      larkin.finishSend(req, res, next, options, outgoing);
+      return larkin.finishSend(req, res, next, options, outgoing);
     }
   };
 
@@ -611,8 +620,12 @@ enum APICapability {
         { ref_id: ref_ids },
         function (error, data) {
           var refs = {};
-          if (!data.rows) {
-            return callback(null);
+          if (error) {
+            larkin.log("error", error);
+            return callback(error);
+          }
+          if (!data || !data.rows) {
+            return callback(null, null);
           }
           for (var i = 0; i < data.rows.length; i++) {
             refs[data.rows[i]["ref_id"]] =
@@ -622,7 +635,7 @@ enum APICapability {
               larkin.normalizeRefField(data.rows[i].doi) +
               larkin.normalizeRefField(data.rows[i].url);
           }
-          callback(refs);
+          callback(null, refs);
         },
       );
 
@@ -652,7 +665,7 @@ enum APICapability {
               larkin.normalizeRefField(result.rows[i].ref_source);
           }
 
-          callback(refs);
+          callback(null, refs);
         },
       );
     }

--- a/v2/units.ts
+++ b/v2/units.ts
@@ -85,14 +85,12 @@ export function getColumnFilters(
   whereClauses.push("cols.status_code::text = ANY(:status_code::text[])");
 
   //only include ANY(macrostrat.core_project_ids()) filter when both col_id and project_id parameters are provided
-  if (req.query.project_id && req.query.col_id) {
-    const [projectFilters, projectParams] = buildProjectsFilter(
-        req,
-        "cols.project_id",
-    );
-    whereClauses.push(...projectFilters);
-    params = {...params, ...projectParams};
-  }
+  const [projectFilters, projectParams] = buildProjectsFilter(
+      req,
+      "cols.project_id",
+  );
+  whereClauses.push(...projectFilters);
+  params = {...params, ...projectParams};
 
   let adjacentsColumnName: string;
   switch (spatialTable) {

--- a/v2/units.ts
+++ b/v2/units.ts
@@ -42,7 +42,7 @@ export async function handleUnitsRoute(req, res, next) {
     );
   } catch (error) {
     larkin.trace(error);
-    return larkin.error(req, res, next, error.message);
+    return larkin.error(req, res, next, error.message, 500);
   }
 }
 
@@ -84,12 +84,15 @@ export function getColumnFilters(
   }
   whereClauses.push("cols.status_code::text = ANY(:status_code::text[])");
 
-  const [projectFilters, projectParams] = buildProjectsFilter(
-    req,
-    "cols.project_id",
-  );
-  whereClauses.push(...projectFilters);
-  params = { ...params, ...projectParams };
+  //only include ANY(macrostrat.core_project_ids()) filter when both col_id and project_id parameters are provided
+  if (req.query.project_id && req.query.col_id) {
+    const [projectFilters, projectParams] = buildProjectsFilter(
+        req,
+        "cols.project_id",
+    );
+    whereClauses.push(...projectFilters);
+    params = {...params, ...projectParams};
+  }
 
   let adjacentsColumnName: string;
   switch (spatialTable) {

--- a/v2/utils/index.ts
+++ b/v2/utils/index.ts
@@ -29,7 +29,7 @@ export function buildProjectsFilter(
       );
       params["project_id"] = larkin.parseMultipleIds(req.query.project_id);
     }
-  } else {
+  } else if (req.query.col_id == null ) { //skips core project filter when col_id is provided without project_id.
     // Default to active projects only
     whereClauses.push(field + " = ANY(macrostrat.core_project_ids())");
   }


### PR DESCRIPTION
I found that the empty response was caused by the units query #275 applying the default project filter even when `col_id` was provided. Since `col_id=4320` belongs to `project_id=3`, and `3` is not included in `macrostrat.core_project_ids()`, the query was filtering out the valid units.

I updated the units route so the project filter is only applied when both `project_id` and `col_id` are provided. Now a `col_id`-only request filters directly by column ID and returns the expected data.

There's a variance between the stored `project_id` lists within dev and prod. Since `col_id` 4320` is associated with only `project_id` `3`, results were returned in dev and not prod. @davenquinn do we need to update the list in production?

```SELECT macrostrat.core_project_ids();```

Dev results:
core_project_ids
"{8,9,7,1,5,4,14,3}"


Prod results:
core_project_ids
"{5,4,8,9,7,1,14}"
