### PR TITLE
updated strat_names tests and updated larkin to return a 500 error

### DIFF
--- a/api-tests/v2Tests/defs_strat_names.ts
+++ b/api-tests/v2Tests/defs_strat_names.ts
@@ -105,3 +105,49 @@ it("should output CSV", function (done) {
       done();
     });
 });
+
+it("should accept rule=all with a strat id", function (done) {
+  request(settings.host)
+    .get("/defs/strat_names?rule=all&strat_name_id=9992")
+    .expect(validators.aSuccessfulRequest)
+    .expect(validators.json)
+    .expect(validators.atLeastOneResult)
+    .expect(function (res) {
+      const hasRequestedStratName = res.body.success.data.some(function (d) {
+        return d.strat_name_id === 9992;
+      });
+
+      if (!hasRequestedStratName) {
+        throw new Error(
+          "defs/strat_names?rule=all&strat_name_id=9992 does not include the requested strat_name_id",
+        );
+      }
+    })
+    .end(function (error, res) {
+      if (error) return done(error);
+      done();
+    });
+});
+
+it("should accept rule=down with a concept id", function (done) {
+  request(settings.host)
+    .get("/defs/strat_names?strat_name_id=9992")
+    .expect(validators.aSuccessfulRequest)
+    .expect(validators.json)
+    .expect(validators.atLeastOneResult)
+    .end(function (error, res) {
+      if (error) return done(error);
+
+      const conceptId = res.body.success.data[0].concept_id;
+
+      request(settings.host)
+        .get("/defs/strat_names?rule=down&concept_id=" + conceptId)
+        .expect(validators.aSuccessfulRequest)
+        .expect(validators.json)
+        .expect(validators.atLeastOneResult)
+        .end(function (error, res) {
+          if (error) return done(error);
+          done();
+        });
+    });
+});

--- a/v2/definitions/strat_names.ts
+++ b/v2/definitions/strat_names.ts
@@ -26,7 +26,7 @@ module.exports = function (req, res, next, cb) {
         );
       } else if (req.query.concept_id) {
         where.push(
-          "parent IN (( SELECT DISTINCT strat_name_id FROM macrostrat.lookup_strat_names WHERE concept_id = ANY(:concept_id) )) OR l.strat_name_id = ANY(( SELECT DISTINCT strat_name_id FROM macrostrat.lookup_strat_names WHERE concept_id IN (:concept_id) ))",
+          "parent IN (( SELECT DISTINCT strat_name_id FROM macrostrat.lookup_strat_names WHERE concept_id = ANY(:concept_id) )) OR l.strat_name_id = ANY(( SELECT DISTINCT strat_name_id FROM macrostrat.lookup_strat_names WHERE concept_id = ANY(:concept_id) ))",
         );
         params["concept_id"] = larkin.parseMultipleIds(req.query.concept_id);
       }
@@ -38,7 +38,7 @@ module.exports = function (req, res, next, cb) {
         params["strat_name"] = req.query.strat_name;
       } else if (req.query.strat_name_id) {
         where.push(
-          "tree = (SELECT tree FROM macrostrat.lookup_strat_names WHERE strat_name_id IN (:strat_name_id))",
+          "tree = (SELECT tree FROM macrostrat.lookup_strat_names WHERE strat_name_id = ANY(:strat_name_id))",
         );
         params["strat_name_id"] = larkin.parseMultipleIds(
           req.query.strat_name_id,
@@ -152,8 +152,8 @@ module.exports = function (req, res, next, cb) {
       if (cb) {
         cb(error);
       } else {
-        larkin.error(req, res, next, "Something went wrong");
-      }
+          larkin.error(req, res, next, error.message || "Internal server error", 500);
+        }
     } else {
       if (cb) {
         cb(null, response.rows);

--- a/v2/larkin.ts
+++ b/v2/larkin.ts
@@ -275,11 +275,12 @@ enum APICapability {
   };
 
   larkin.error = function (req, res, next, message, code) {
+    const statusCode = code || 500;
     var responseMessage = message
       ? message
       : "Something went wrong. Please contact the Macrostrat team.";
-    if ((code && code === 500) || code === 404) {
-      res.status(code ? code : 200).json({
+    if (statusCode === 500 || statusCode === 404) {
+      return res.status(statusCode).json({
         error: {
           message: responseMessage,
         },
@@ -291,7 +292,7 @@ enum APICapability {
         .replace(/\/$/, "")
         .replace("/v" + api.version, "");
       this.defineRoute(formatted, function (definition) {
-        res.status(code ? code : 200).json({
+        res.status(statusCode).json({
           error: {
             v: api.version,
             license: api.license,


### PR DESCRIPTION
References issue (https://github.com/UW-Macrostrat/web/issues/409)
Updated `/defs/strat_names` query handling to correctly use `ANY(:param)` for parameters parsed with `parseMultipleIds(...)`. This fixes SQL errors caused by passing parsed ID arrays into `IN (:param)` clauses, which Postgres interpreted incorrectly.

Also updated API error handling so database/query errors return an actual `500` status code with the underlying error message instead of returning a misleading successful response with `"Something went wrong"`. Added regression tests for `rule=all&strat_name_id` and `rule=down&concept_id` to ensure array-style ID parameters are handled correctly.

<img width="1196" height="512" alt="image" src="https://github.com/user-attachments/assets/d3830094-490b-41b4-81f7-ca18b351ecc7" />
